### PR TITLE
Updating Kabanero Logging and Monitoring guides for RHOCP 4.3

### DIFF
--- a/publish/app-logging-ocp-4.2/app-logging-ocp-4.2.md
+++ b/publish/app-logging-ocp-4.2/app-logging-ocp-4.2.md
@@ -1,7 +1,7 @@
 ---
 permalink: /guides/app-logging-ocp-4-2/
 layout: guide-markdown
-title: Application Logging with Elasticsearch, Fluentd, and Kibana
+title: Application Logging on Red Hat OpenShift Container Platform (RHOCP) 4.3 with Elasticsearch, Fluentd, and Kibana
 duration: 30 minutes
 releasedate: 2020-02-19
 description: Learn how to do application logging with Elasticsearch, Fluentd, and Kibana.
@@ -32,7 +32,7 @@ guide-category: basic
 //
 -->
 
-**The following guide has been tested with Red Hat OpenShift Container Platform (RHOCP) 4.2/Kabanero 0.3.0.**
+**The following guide has been tested with Red Hat OpenShift Container Platform (RHOCP) 4.2/Kabanero 0.3.0 and RHOCP 4.3/Kabanero 0.6.0.**
 
 Pod processes running in Kubernetes frequently produce logs. To effectively manage this log data and ensure no loss of log data occurs when a pod terminates, a log aggregation tool should be deployed on the Kubernetes cluster. Log aggregation tools help users persist, search, and visualize the log data that is gathered from the pods across the cluster. Log aggregation tools in the market today include:  EFK, LogDNA, Splunk, Datadog, IBM Operations Analytics, etc.  When considering log aggregation tools, enterprises will make choices that are inclusive of their journey to cloud, both new cloud native applications running in Kubernetes and their existing traditional IT choices.
 
@@ -46,7 +46,7 @@ One choice for application logging with log aggregation, based on open source, i
 
 ## Install cluster logging
 
-To install the cluster logging component, follow the OpenShift guide [Deploying cluster logging](https://docs.openshift.com/container-platform/4.2/logging/cluster-logging-deploying.html)
+To install the cluster logging component, follow the OpenShift guide [Deploying cluster logging](https://docs.openshift.com/container-platform/4.3/logging/cluster-logging-deploying.html)
 
 After the installation completes without any error, you can see the following pods that are running in the *openshift-logging* namespace. The exact number of pods running for each of the EFK components can vary depending on the configuration specified in the ClusterLogging Custom Resource (CR).
 

--- a/publish/app-logging-ocp-4.2/app-logging-ocp-4.2.md
+++ b/publish/app-logging-ocp-4.2/app-logging-ocp-4.2.md
@@ -3,7 +3,7 @@ permalink: /guides/app-logging-ocp-4-2/
 layout: guide-markdown
 title: Application Logging on Red Hat OpenShift Container Platform (RHOCP) 4.3 with Elasticsearch, Fluentd, and Kibana
 duration: 30 minutes
-releasedate: 2020-02-19
+releasedate: 2020-03-26
 description: Learn how to do application logging with Elasticsearch, Fluentd, and Kibana.
 tags: ['logging', 'Elasticsearch', 'Fluentd', 'Kibana']
 guide-category: basic

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -4,7 +4,7 @@ permalink: /guides/app-monitoring-ocp4.2/
 :projectid: ocp-app-monitoring
 :page-layout: guide-multipane
 :page-duration: 60 minutes
-:page-releasedate: 2020-02-02
+:page-releasedate: 2020-03-26
 :page-guide-category: basic
 :page-description: Learn how to monitor applications on RHOCP 4.2 with Prometheus and Grafana.
 :page-tags: ['monitoring', 'prometheus', 'grafana']
@@ -15,7 +15,7 @@ permalink: /guides/app-monitoring-ocp4.2/
 __The following guide has been tested with RHOCP 4.2/Kabanero 0.3.0 and RHOCP 4.3/Kabanero 0.6.0.__
 
 
-For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Both Prometheus and Grafana can be set up via Operator Lifecycle Manager (OLM). 
+For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Prometheus and Grafana can be set up via *Operator Lifecycle Manager (OLM)* or through the *Common Services* installation. If you are using the Common Services Prometheus and Grafana monitoring stack, skip to https://kabanero.io/guides/app-monitoring-ocp4.2/#configure-prometheus-operator-to-detect-service-monitors-in-other-namespaces[Configure Prometheus Operator to Detect Service Monitors in Other Namespaces].
 
 === Deploy an Application with MP Metrics Endpoint
 Prior to deploying Prometheus, ensure that there is a running application that has a service endpoint for outputting metrics in Prometheus format. 
@@ -43,11 +43,11 @@ include::code/prometheus.yaml[]
 ----
 
 
-The Prometheus Operator is an open-source project originating from CoreOS and exists as a part of their Kubernetes Operator framework. The Kubernetes Operator framework is the preferred way to deploy Prometheus on a Kubernetes system. When the Prometheus Operator is installed on the Kubernetes system, you no longer need to hand-configure the Prometheus configuration. Instead, you create CoreOS ServiceMonitor resources for each of the service endpoints that needs to be monitored: this makes daily maintenance of the Prometheus server a lot easier. An architecture overview of the Prometheus Operator is shown below:
+The Prometheus Operator is an open-source project originating from CoreOS and exists as a part of their Kubernetes Operator framework. When the Prometheus Operator is installed on the Kubernetes system, you no longer need to hand-configure the Prometheus configuration. Instead, you create CoreOS ServiceMonitor resources for each of the service endpoints that needs to be monitored: this makes daily maintenance of the Prometheus server a lot easier. An architecture overview of the Prometheus Operator is shown below:
 
 image::/img/guide/prometheusOperator.png[link="/img/guide/prometheusOperator.png" alt="Prometheus Operator"]
 
-Using Operator Lifecycle Manager (OLM), Prometheus operator can be easily installed and configured in RHOCP Web Console.
+Using Operator Lifecycle Manager (OLM), Prometheus operator can be easily installed and configured in RHOCP Web Console. 
 
 === Install Prometheus Operator Using Operator Lifecycle Manager (OLM)
 
@@ -72,7 +72,7 @@ Refer to the `service_monitor.yaml` file
 ----
 +
 
-. Create a Service Account with Cluster role and Cluster role binding to ensure you have the permission to get nodes and pods in other namespaces at the cluster scope. Refer to [hotspot file=1]`service_account.yaml`. Create the YAML file and apply it.
+. Create a Prometheus Service Account and Cluster Role, and define a Cluster Role Binding to bind the two together. This is to ensure Prometheus has cluster-wide access to the metrics endpoint on pods in other namespaces. Refer to [hotspot file=1]`service_account.yaml`. Create the YAML file and apply it.
 +
 [role=command]
 ----
@@ -190,7 +190,7 @@ Apply `grafana_dashboard.yaml` file to check
 ----
 +
 
-. Click on Networking > Routes and go to Grafana's location to see the template dashboard. You can now consume all the application metrics gathered by Prometheus on the Grafana dashboard.
+. Click on Networking > Routes and go to Grafana's location to see the sample dashboard. You can now consume all the application metrics gathered by Prometheus on the Grafana dashboard.
 
 image::/img/guide/template_grafana_dashboard.png[link="/img/guide/template_grafana_dashboard.png" alt="Template Dashboard"]
 
@@ -207,7 +207,7 @@ Depending on whether you have installed the Prometheus Operator from OLM or if y
 
 === Using the Prometheus Operator Installed from OLM
 
-. In your monitoring namespace - in this case, the monitoring namespace is `prometheus-operator` - edit the OperatorGroup to add your application's namespace `myapp` to the list of targeted namesaces to be watched. This will change the *olm.targetNamespaces* variable that the Prometheus Operator uses for detecting namespaces to include your `myapp` namespace.
+. In your monitoring namespace - in this case, the monitoring namespace is `prometheus-operator` - edit the OperatorGroup to add your application's namespace, for example, `myapp`, to the list of targeted namesaces to be watched. This will change the *olm.targetNamespaces* variable that the Prometheus Operator uses for detecting namespaces to include your `myapp` namespace.
 +
 [role="command"]
 ----
@@ -242,7 +242,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: true       # this line should be true
     type: MultiNamespace
   - supported: false
     type: AllNamespaces
@@ -261,7 +261,7 @@ oc edit csv grafana-operator.v2.0.0 
 +
 [role="command"]
 ----
-oc edit prometheus
+oc edit prometheuses.monitoring.coreos.com prometheus
 ----
 +
 
@@ -277,7 +277,7 @@ spec:
 
 === Using the Prometheus Operator Deployment from Common Services
 
-. In the `kube-system` namespace, edit the existing `monitoring-prometheus-operator` deployment to add your application's namespace `myapp` to the list of namespaces to be watched:
+. In the `kube-system` namespace, edit the existing `monitoring-prometheus-operator` deployment to add your application's namespace, for example `myapp`, to the list of namespaces to be watched:
 
 +
 [role="command"]
@@ -307,7 +307,7 @@ spec:
 +
 [role="command"]
 ----
-oc edit prometheus
+oc edit prometheuses.monitoring.coreos.com prometheus
 ----
 +
 
@@ -318,3 +318,8 @@ spec:
   serviceMonitorNamespaceSelector: {}
 ----
 +
+
+
+== Installation Complete
+
+You now have the Prometheus and Grafana stack installed and configured to monitor your applications. Import custom dashboards and visit the Grafana route to see your metrics visualized.

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -201,7 +201,7 @@ image::/img/guide/template_grafana_dashboard.png[link="/img/guide/template_grafa
 
 == Configure Prometheus Operator to Detect Service Monitors in Other Namespaces
 
-By default, the Prometheus Operator only watches the namespace it currently resides in, so in order to get the Prometheus Operator to detect Service Monitors created in other namespaces, you must apply the following configuration changes.
+By default, the Prometheus Operator only watches the namespace it currently resides in, so in order to get the Prometheus Operator to detect service monitors created in other namespaces, you must apply the following configuration changes.
 
 . In your monitoring namespace - in this case, the monitoring namespace is `prometheus-operator` - edit the OperatorGroup to add your application's namespace, for example, `myapp`, to the list of targeted namesaces to be watched. This will change the *olm.targetNamespaces* variable that the Prometheus Operator uses for detecting namespaces to include your `myapp` namespace.
 +

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -8,11 +8,11 @@ permalink: /guides/app-monitoring-ocp4.2/
 :page-guide-category: basic
 :page-description: Learn how to monitor applications on RHOCP 4.2 with Prometheus and Grafana.
 :page-tags: ['monitoring', 'prometheus', 'grafana']
-= Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) 4.2 with Prometheus and Grafana
+= Application Monitoring on Red Hat OpenShift Container Platform (RHOCP) 4.3 with Prometheus and Grafana
 
 == Introduction
 
-__The following guide has been tested with RHOCP 4.2/Kabanero 0.3.0.__
+__The following guide has been tested with RHOCP 4.2/Kabanero 0.3.0 and RHOCP 4.3/Kabanero 0.6.0.__
 
 
 For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Both Prometheus and Grafana can be set up via Operator Lifecycle Manager (OLM). 
@@ -198,3 +198,123 @@ image::/img/guide/template_grafana_dashboard.png[link="/img/guide/template_grafa
 
 . When importing your own Grafana dashboard, your dashboard should be configured under *spec.json* in Grafana Dashboard YAML file. Make sure under *"__inputs"*, the name matches with your Grafana Data Source's *spec.datasources*. For example, inside [hotspot file=2]`grafana_dashboard.yaml` file, *name* is set to "Prometheus".
 
+
+== Configure Prometheus Operator to Detect Service Monitors in Other Namespaces
+
+By default, the Prometheus Operator only watches the namespace it currently resides in, so in order to get the Prometheus Operator to detect Service Monitors created in other namespaces, you must apply the following configuration changes.
+
+Depending on whether you have installed the Prometheus Operator from OLM or if you are using the Prometheus Operator deployment from Common Services, see the following sections to configure the Prometheus Operator to detect Service Monitors outside of the monitoring namespace.
+
+=== Using the Prometheus Operator Installed from OLM
+
+. In your monitoring namespace - in this case, the monitoring namespace is `prometheus-operator` - edit the OperatorGroup to add your application's namespace `myapp` to the list of targeted namesaces to be watched. This will change the *olm.targetNamespaces* variable that the Prometheus Operator uses for detecting namespaces to include your `myapp` namespace.
++
+[role="command"]
+----
+oc edit operatorgroup
+----
++
+
++
+[source,role="no_copy"]
+----
+spec:
+  targetNamespaces:
+  - prometheus-operator
+  - myapp
+----
++
+
+. Since we have changed the `prometheus-operator` namespace's OperatorGroup to monitor more than one namespace, the operators in this namespace must have the *MultiNamespace* installMode set to *true*. Prometheus Operator installed via OLM has the *MultiNamespace* installMode set to *false* by default, disabling monitoring more than one namespace, so this must be changed to *true*.
++
+[role="command"]
+----
+oc edit csv prometheusoperator.0.32.0
+----
++
+
++
+[source,role="no_copy"]
+----
+spec:
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+----
++
+
+. The same goes for the Grafana Operator, the *MultiNamespace* installMode set to *true*; edit the operator using:
++
+[role="command"]
+----
+oc edit csv grafana-operator.v2.0.0 
+----
++
+
+. Edit the Prometheus instance to add the *serviceMonitorNamespaceSelector* definition. The empty brackets *{}* allow Prometheus to scrape from *all* namespaces:
++
+[role="command"]
+----
+oc edit prometheus
+----
++
+
++
+[source,role="no_copy"]
+----
+spec:
+  serviceMonitorNamespaceSelector: {}
+----
++
+
+Restart the Prometheus Operator and Grafana Operator pods to see the changes.
+
+=== Using the Prometheus Operator Deployment from Common Services
+
+. In the `kube-system` namespace, edit the existing `monitoring-prometheus-operator` deployment to add your application's namespace `myapp` to the list of namespaces to be watched:
+
++
+[role="command"]
+----
+oc edit deployment monitoring-prometheus-operator
+----
++
+
++
+[source,role="no_copy"]
+----
+spec:
+  ...
+  template:
+    ...
+    spec:
+      ...
+      containers:
+        ...
+        args: 
+        - '--namespaces=kube-system, myapp'
+----
++
+
+. Edit the Prometheus instance to add the *serviceMonitorNamespaceSelector* definition. The empty brackets *{}* allow Prometheus to scrape from *all* namespaces:
+
++
+[role="command"]
+----
+oc edit prometheus
+----
++
+
++
+[source,role="no_copy"]
+----
+spec:
+  serviceMonitorNamespaceSelector: {}
+----
++

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -82,7 +82,7 @@ oc apply -f service_account.yaml
 
 . Click on Overview and create a Prometheus instance. A Prometheus resource can scrape the targets defined in the ServiceMonitor resource.
 
-. Inside the Prometheus YAML file, make sure *metadata.namespace* is prometheus-operator. Ensure *spec.serviceAccountName* is the Service Account's name that you have applied in the previous step. You can set the match expression to select which Service Monitors you are interested in under *spec.serviceMonitorSelector.matchExpressions* as in [hotspot file=2]`prometheus.yaml` file.
+. Inside the Prometheus YAML file, make sure *metadata.namespace* is prometheus-operator. Ensure *spec.serviceAccountName* is the Service Account's name that you have applied in the previous step. You can set the match expression to select which service monitors you are interested in under *spec.serviceMonitorSelector.matchExpressions* as in [hotspot file=2]`prometheus.yaml` file.
 +
 [role="code_command hotspot file=2", subs="quotes"]
 ----

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -15,12 +15,14 @@ permalink: /guides/app-monitoring-ocp4.2/
 __The following guide has been tested with RHOCP 4.2/Kabanero 0.3.0 and RHOCP 4.3/Kabanero 0.6.0.__
 
 
-For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Prometheus and Grafana can be set up via *Operator Lifecycle Manager (OLM)* or through the *Common Services* installation. If you are using the Common Services Prometheus and Grafana monitoring stack, skip to https://kabanero.io/guides/app-monitoring-ocp4.2/#configure-prometheus-operator-to-detect-service-monitors-in-other-namespaces[Configure Prometheus Operator to Detect Service Monitors in Other Namespaces].
+For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Prometheus and Grafana can be set up via *Operator Lifecycle Manager (OLM)* or through the *Common Services* installation.
 
 === Deploy an Application with MP Metrics Endpoint
 Prior to deploying Prometheus, ensure that there is a running application that has a service endpoint for outputting metrics in Prometheus format. 
 
 It is assumed such a running application has been deployed to the RHOCP cluster inside a project/namespace called `myapp`, and that the Prometheus metrics endpoint is exposed on path `/metrics`.
+
+If you are using the Common Services Prometheus and Grafana monitoring stack, skip to https://kabanero.io/guides/app-monitoring-ocp4.2/#configure-prometheus-operator-to-detect-service-monitors-in-other-namespaces[Configure Prometheus Operator to Detect Service Monitors in Other Namespaces].
 
 == Deploy Prometheus - Prometheus Operator
 

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -225,7 +225,7 @@ spec:
 ----
 +
 
-. Since we have changed the `prometheus-operator` namespace's OperatorGroup to monitor more than one namespace, the operators in this namespace must have the *MultiNamespace* installMode set to *true*. Prometheus Operator installed via OLM has the *MultiNamespace* installMode set to *false* by default, disabling monitoring more than one namespace, so this must be changed to *true*.
+. Since we have changed the `prometheus-operator` namespace's OperatorGroup to monitor more than one namespace, the operators in this namespace must have the *MultiNamespace* installMode set to *true*. Prometheus Operator installed via OLM has the *MultiNamespace* installMode set to *false* by default, disabling monitoring for more than one namespace, so this must be changed to *true*.
 +
 [role="command"]
 ----
@@ -249,7 +249,7 @@ spec:
 ----
 +
 
-. The same goes for the Grafana Operator, the *MultiNamespace* installMode set to *true*; edit the operator using:
+. The same goes for the Grafana Operator, the *MultiNamespace* installMode should be set to *true*; edit the operator using:
 +
 [role="command"]
 ----
@@ -273,7 +273,7 @@ spec:
 ----
 +
 
-Restart the Prometheus Operator and Grafana Operator pods to see the changes.
+. Restart the Prometheus Operator and Grafana Operator pods to see the changes.
 
 === Using the Prometheus Operator Deployment from Common Services
 

--- a/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
+++ b/publish/app-monitoring-ocp-4.2/app-monitoring-ocp-4.2.adoc
@@ -15,14 +15,12 @@ permalink: /guides/app-monitoring-ocp4.2/
 __The following guide has been tested with RHOCP 4.2/Kabanero 0.3.0 and RHOCP 4.3/Kabanero 0.6.0.__
 
 
-For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Prometheus and Grafana can be set up via *Operator Lifecycle Manager (OLM)* or through the *Common Services* installation.
+For application monitoring on RHOCP, you need to set up your own Prometheus and Grafana deployments. Both Prometheus and Grafana can be set up via Operator Lifecycle Manager (OLM).
 
 === Deploy an Application with MP Metrics Endpoint
 Prior to deploying Prometheus, ensure that there is a running application that has a service endpoint for outputting metrics in Prometheus format. 
 
 It is assumed such a running application has been deployed to the RHOCP cluster inside a project/namespace called `myapp`, and that the Prometheus metrics endpoint is exposed on path `/metrics`.
-
-If you are using the Common Services Prometheus and Grafana monitoring stack, skip to https://kabanero.io/guides/app-monitoring-ocp4.2/#configure-prometheus-operator-to-detect-service-monitors-in-other-namespaces[Configure Prometheus Operator to Detect Service Monitors in Other Namespaces].
 
 == Deploy Prometheus - Prometheus Operator
 
@@ -205,10 +203,6 @@ image::/img/guide/template_grafana_dashboard.png[link="/img/guide/template_grafa
 
 By default, the Prometheus Operator only watches the namespace it currently resides in, so in order to get the Prometheus Operator to detect Service Monitors created in other namespaces, you must apply the following configuration changes.
 
-Depending on whether you have installed the Prometheus Operator from OLM or if you are using the Prometheus Operator deployment from Common Services, see the following sections to configure the Prometheus Operator to detect Service Monitors outside of the monitoring namespace.
-
-=== Using the Prometheus Operator Installed from OLM
-
 . In your monitoring namespace - in this case, the monitoring namespace is `prometheus-operator` - edit the OperatorGroup to add your application's namespace, for example, `myapp`, to the list of targeted namesaces to be watched. This will change the *olm.targetNamespaces* variable that the Prometheus Operator uses for detecting namespaces to include your `myapp` namespace.
 +
 [role="command"]
@@ -276,51 +270,6 @@ spec:
 +
 
 . Restart the Prometheus Operator and Grafana Operator pods to see the changes.
-
-=== Using the Prometheus Operator Deployment from Common Services
-
-. In the `kube-system` namespace, edit the existing `monitoring-prometheus-operator` deployment to add your application's namespace, for example `myapp`, to the list of namespaces to be watched:
-
-+
-[role="command"]
-----
-oc edit deployment monitoring-prometheus-operator
-----
-+
-
-+
-[source,role="no_copy"]
-----
-spec:
-  ...
-  template:
-    ...
-    spec:
-      ...
-      containers:
-        ...
-        args: 
-        - '--namespaces=kube-system, myapp'
-----
-+
-
-. Edit the Prometheus instance to add the *serviceMonitorNamespaceSelector* definition. The empty brackets *{}* allow Prometheus to scrape from *all* namespaces:
-
-+
-[role="command"]
-----
-oc edit prometheuses.monitoring.coreos.com prometheus
-----
-+
-
-+
-[source,role="no_copy"]
-----
-spec:
-  serviceMonitorNamespaceSelector: {}
-----
-+
-
 
 == Installation Complete
 


### PR DESCRIPTION
This PR is to update the current Kabanero Logging and Monitoring guides for RHOCP 4.2 to be compatible for RHOCP 4.3.

The RHOCP 4.2 guides are already compatible for RHOCP 4.3, major differences are changing titles, "tested with" statements, and links to OpenShift guides for 4.3.

For monitoring, a section on "Configure Prometheus Operator to Detect Service Monitors in Other Namespaces" was added that is needed for both RHOCP 4.2 and 4.3 use.