### PR TITLE
Add further information on how to configure your deployment enviroment

### DIFF
--- a/publish/creating-a-stack-hub/creating-a-stack-hub.md
+++ b/publish/creating-a-stack-hub/creating-a-stack-hub.md
@@ -36,7 +36,7 @@ A stack hub is the central control point for application stacks that you want to
 be clones of public stacks or they might be customized to meet local requirements. For example, you might want to include
 templates with unique starter applications, specify a different test framework, or ensure that your applications are developed on specific software levels.
 
-Before building a stack hub you should identify the stacks that you want to use for developing your microservice applications. Clone the available stacks and make any modifications that are needed. How to customize, package, and publish stacks is covered in the [Working with stacks](../working-with-stacks/) guide.
+Before building a stack hub you should identify the stacks that you want to use for developing your microservice applications. Clone the available stacks and make any modifications that are needed. How to customize, package, and publish stacks is covered in the [Customizing applications stacks](../working-with-stacks/) guide.
 
 In this guide we will cover how to build a stack hub that consolidates multiple application stacks for use in your organization and how to use the assets in your deployment environment.
 
@@ -53,7 +53,7 @@ The following prerequisites apply to your local system:
 Stack hubs are created from a configuration file. For a suitable starting point, clone the following repository, which contains example files:
 
 ```
-git clone https://github.com/kabanero/kabanero-stack-hub.git
+git clone https://github.com/kabanero-io/kabanero-stack-hub.git
 ```
 In this repository, you can find the following key files:
 
@@ -113,34 +113,34 @@ In this guide, you will change the example configuration file and use it build a
 
 1. Edit the `example_config/example_repo_config.yaml` file to include the following values for your stack hub:
 
-```
-# File: example_repo_config.yaml
-# My organization stack hub
-name: My.org Stack Hub
-description: Test configuration to build 2 index files for the default and incubator repos.
-version: 0.1.0
-stacks:
-  - name: default
-    repos:
-      - url: https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-        exclude:
-          - kitura
-          - node-red
-          - python-flask
-          - starter
-          - swift
-          - java-microprofile
-          - nodejs
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
-        include:
-          - java-microprofile
-image-org:
-image-registry:
-nginx-image-name:
-```
+    ```
+    # File: example_repo_config.yaml
+    # My organization stack hub
+    name: My.org Stack Hub
+    description: Test configuration to build 2 index files for the default and incubator repos.
+    version: 0.1.0
+    stacks:
+      - name: default
+        repos:
+          - url: https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
+            exclude:
+              - kitura
+              - node-red
+              - python-flask
+              - starter
+              - swift
+              - java-microprofile
+              - nodejs
+          - url: https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
+            include:
+              - java-microprofile
+    image-org:
+    image-registry:
+    nginx-image-name:
+    ```
 
-This example configuration file builds a single stack hub index file for your `default` hub. The `default` hub points to two index files, `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` and `https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml`. The `include:` and `exclude:` options are used
-to filter from the available application stacks.
+    This example configuration file builds a single stack hub index file for your `default` hub. The `default` hub points to two index files, `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` and `https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml`. The `include:` and `exclude:` options are used
+    to filter from the available application stacks.
 
 2. Save your changes.
 
@@ -220,18 +220,71 @@ Creating consolidated index for default
 Congratulations! You have built your first stack hub index file that defines a set of filtered application stacks from multiple source repositories. This index file should be hosted somewhere that is accessible to developers, such as a GitHub repository. Typically, you would create a release for a final version of the index file, and reference the index file from a URL that is similar to `https://github.com/myorg/my-org-repository/releases/latest/download/default-index.yaml`.
 
 
-## Configuring your deployment environment
+## Configuring your Kubernetes environment
 
-Your deployment environment also needs to know about the application stacks that should be used to build deployment containers. You  must update your Kubernetes operator custom resource (CR) definition file to reference your stack hub index file.
+Your deployment environment also needs to know about the application stacks that should be used to build deployment containers. You must update your Kabanero operator custom resource definition (CRD) file to reference your stack hub index file.
 
-Edit the `stacks:` section of your Kubernetes operator CR definition file to include the URL for your stack hub index file.
 
-For example:
+Follow these steps:
 
-```
-stacks:
-  repositories:
-  - name: default
-    https:
-      url: https://github.com/myorg/my-org-repository/releases/latest/download/default-index.yaml
-```
+1. Obtain a copy of your current Kabanero CR instance configuration.
+
+    To obtain a list of all Kabanero CR instances in the kabanero namespace, run the following command:
+
+    ```
+    oc get kabaneros -n kabanero
+    ```
+
+    To obtain the configuration for a specific CR instance, run the following command, substituting `<name>` for the instance you are targeting:
+
+    ```
+    oc get kabanero <name> -n kabanero -o yaml > kabanero.yaml
+    ```
+
+    This example assumes that you kept the default `<name>`, which is `kabanero`.
+
+2. Edit the `kabanero.yaml` file that you generated in the last step.
+
+    Update the following section, which shows the configuration for stack repositories:
+
+    ```
+    stacks:
+      repositories:
+      - name:
+        https:
+          url:
+          skipCertVerification: [true|false]
+      - name:
+        https:
+          url:
+          skipCertVerification: [true|false]
+    ```
+
+    Where:
+
+    - `repositories` lists the repositories to search for stacks
+    - `name` is the name of your repository
+    - `url` contains the URL string for the `index.yaml` file
+    - `skipCertVerification` determines whether to verify the certificate before activating (default is `false`)
+
+    To change the desired state for a repository after the instance is deployed, you must edit each resource manually.
+
+    The following configuration can be used for the repository you created earlier:
+
+    ```
+    stacks:
+      repositories:
+      - name: my-org-repository
+        https:
+          url: https://github.com/myorg/my-org-repository/releases/latest/download/my-org-repository-index.yaml
+    ```
+
+3. Save the file.
+
+4. Apply the changes to your Kabanero CR instance with the following command:
+
+    ```
+    oc apply -f kabanero.yaml -n kabanero
+    ```
+
+Applications that are developed using the stacks defined in your stack hub can now be deployed to your Kubernetes cluster.

--- a/publish/working-with-stacks/working-with-stacks.md
+++ b/publish/working-with-stacks/working-with-stacks.md
@@ -1,7 +1,7 @@
 ---
 permalink: /guides/working-with-stacks/
 layout: guide-markdown
-title: Working with application stacks
+title: Customizing application stacks
 duration: 40 minutes
 releasedate: 2020-02-06
 description: Learn how to create, update, build, test, and publish application stacks
@@ -217,66 +217,94 @@ Now that your stack is available in your local repository, the next step is to r
 3. Create a draft GitHub release for your stack, which places the source code and archives into a download folder. See [Creating releases](https://help.github.com/en/github/administering-a-repository/creating-releases).
 4. From the top level directory of your stack, run the following command to add your stack to the `my-org-repository` repository, referencing the release URL:
 
-```
-appsody stack add-to-repo my-org-repository --release-url https://github.com/myorg/my-org-repository/releases/latest/download/
-```
+    ```
+    appsody stack add-to-repo my-org-repository --release-url https://github.com/myorg/my-org-repository/releases/latest/download/
+    ```
 
-The output from this command is similar to the following example:
+    The output from this command is similar to the following example:
 
-```
-******************************************
-Running appsody stack add-to-repo
-******************************************
-Creating repository index file: /Users/user1/.appsody/stacks/dev.local/my-org-repository-index.yaml
-Repository index file updated successfully
-```
+    ```
+    ******************************************
+    Running appsody stack add-to-repo
+    ******************************************
+    Creating repository index file: /Users/user1/.appsody/stacks/dev.local/my-org-repository-index.yaml
+    Repository index file updated successfully
+    ```
 
 5. Upload the repository index file that is created in your `.appsody/stacks/dev.local` directory to your GitHub repository. Add it to your draft release and then publish the release.
 
-Share your URL for the index file with developers who can add it to their local repository list with the `appsody repo add` command. For example:
 
-```
-appsody repo add https://github.com/myorg/my-org-repository/releases/latest/download/my-org-repository-index.yaml
-```
+Now that you have released your application stack you can share your URL for the index file with developers. Developers must configure their local development environment to access the stack in one of the following ways:
 
-Developers can now create applications based on your customized stack in their local development environment.
+  - Developers who are using the CLI from the Appsody project can add it to their local repository list with the `appsody repo add` command. For more information, see [Developing microservice applications with the CLI](../use-appsody-cli/)
+  - Developers who are using an IDE with the Eclipse Codewind extension can configure their template sources. For more information, see [Getting Started with Codewind and VSCode](../codewind-getting-started-vscode/) or [Getting Started with Codewind and Eclipse](../codewind-getting-started-eclipse/).
 
-## Configuring the Kubernetes operator custom resource definition
+Developers can now create applications based on your customized stack in their local development environment. If you plan to make more than one  application stack available to developers, you might want to consider creating a stack hub. For more information, see [Creating a stack hub](../creating-a-stack-hub/).
 
-In order to deploy containerized applications that have been developed using your application stack, you must configure Kubernetes with information about the application stack and the deployment container that must be used. This configuration forms part of the operator custom resource definition (CRD).
+## Configuring your Kubernetes environment
 
-The following section shows the configuration for stack repositories:
+In order to deploy containerized applications that have been developed using your application stack, you must configure Kubernetes with information about the application stack and the deployment container that must be used. This configuration forms part of the Kabanero operator custom resource definition (CRD). The process is the same whether your URL defines a single application stack or a stack hub that contains multiple application stacks.
 
-```
-stacks:
-  repositories:
-  - name:
-    https:
-      url:
-      skipCertVerification: [true|false]
-  - name:
-    https:
-      url:
-      skipCertVerification: [true|false]
-```
+Follow these steps:
 
-Where:
+1. Obtain a copy of your current Kabanero CR instance configuration.
 
-- `repositories` lists the repositories to search for stacks
-- `name` is the name of your repository
-- `url` contains the URL string for the `index.yaml` file
-- `skipCertVerification` determines whether to verify the certificate before activating (default is `false`)
+    To obtain a list of all Kabanero CR instances in the kabanero namespace, run the following command:
 
-To change the desired state for a repository after the instance is deployed, you must edit each resource manually.
+    ```
+    oc get kabaneros -n kabanero
+    ```
 
-The following configuration can be used for the repository you created earlier:
+    To obtain the configuration for a specific CR instance, run the following command, substituting `<name>` for the instance you are targeting:
 
-```
-stacks:
-  repositories:
-  - name: my-org-repository
-    https:
-      url: https://github.com/myorg/my-org-repository/releases/latest/download/my-org-repository-index.yaml
-```
+    ```
+    oc get kabanero <name> -n kabanero -o yaml > kabanero.yaml
+    ```
 
-Edit your Kabanero CR instance to include the stack configuration and deploy it. Applications that have been developed using your stack can now be deployed to your Kubernetes cluster.
+    This example assumes that you kept the default `<name>`, which is `kabanero`.
+
+2. Edit the `kabanero.yaml` file that you generated in the last step.
+
+    Update the following section, which shows the configuration for stack repositories:
+
+    ```
+    stacks:
+      repositories:
+      - name:
+        https:
+          url:
+          skipCertVerification: [true|false]
+      - name:
+        https:
+          url:
+          skipCertVerification: [true|false]
+    ```
+
+    Where:
+
+    - `repositories` lists the repositories to search for stacks
+    - `name` is the name of your repository
+    - `url` contains the URL string for the `index.yaml` file
+    - `skipCertVerification` determines whether to verify the certificate before activating (default is `false`)
+
+    To change the desired state for a repository after the instance is deployed, you must edit each resource manually.
+
+    The following configuration can be used for the repository you created earlier:
+
+    ```
+    stacks:
+      repositories:
+      - name: my-org-repository
+        https:
+          url: https://github.com/myorg/my-org-repository/releases/latest/download/my-org-repository-index.yaml
+    ```
+
+3. Save the file.
+
+4. Apply the changes to your Kabanero CR instance with the following command:
+
+    ```
+    oc apply -f kabanero.yaml -n kabanero
+    ```
+
+Applications that have been developed using your stack can now be deployed to your Kubernetes cluster.


### PR DESCRIPTION
Addressing #19, to improve how an architect/devops would configure their Kabanero
CRD to use customized application stacks.

Other improvements in this PR:

- Change title of guide to "Customizing application stacks", which is more accurate.
- Add further information for how developers would customize their local dev environments with links to other guides
- Fix ordered lists by adjusting indenting.

Closes: #19

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>