### PR TITLE
Update version number in guides

### DIFF
--- a/publish/creating-a-stack-hub/creating-a-stack-hub.md
+++ b/publish/creating-a-stack-hub/creating-a-stack-hub.md
@@ -132,7 +132,7 @@ In this guide, you will change the example configuration file and use it build a
               - java-microprofile
               - java-openliberty
               - nodejs
-          - url: https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
+          - url: https://github.com/kabanero-io/collections/releases/download/0.9.0/kabanero-index.yaml
             include:
               - java-openliberty
     image-org:
@@ -140,7 +140,7 @@ In this guide, you will change the example configuration file and use it build a
     nginx-image-name:
     ```
 
-    This example configuration file builds a single stack hub index file for your `default` hub. The `default` hub points to two index files, `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` and `https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml`. The `include:` and `exclude:` options are used
+    This example configuration file builds a single stack hub index file for your `default` hub. The `default` hub points to two index files, `https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml` and `https://github.com/kabanero-io/collections/releases/download/0.9.0/kabanero-index.yaml`. The `include:` and `exclude:` options are used
     to filter from the available application stacks.
 
 2. Save your changes.
@@ -166,25 +166,25 @@ Not retrieving or modifying any assets
 Creating consolidated index for default
 == fetching https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 == Adding stacks from index https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-==== Adding stack nodejs-loopback 0.2.2
+==== Adding stack nodejs-loopback 0.3.0
 ==== Excluding stack swift 0.2.5
 ==== Excluding stack node-red 0.1.1
-==== Excluding stack python-flask 0.2.2
+==== Excluding stack python-flask 0.2.3
 ==== Excluding stack starter 0.1.2
-==== Excluding stack java-microprofile 0.2.24
-==== Adding stack java-spring-boot2 0.3.26
-==== Excluding stack kitura 0.2.5
-==== Excluding stack java-openliberty 0.2.2
-==== Excluding stack nodejs 0.3.4
-==== Adding stack nodejs-express 0.4.3
-== fetching https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
-== Adding stacks from index https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
-==== Excluding stack java-microprofile 0.2.25
-==== Adding stack java-openliberty 0.2.1
-==== Excluding stack java-spring-boot2 0.3.23
-==== Excluding stack nodejs-express 0.2.8
-==== Excluding stack nodejs-loopback 0.1.8
-==== Excluding stack nodejs 0.3.1
+==== Excluding stack java-microprofile 0.2.26
+==== Adding stack java-spring-boot2 0.3.29
+==== Excluding stack kitura 0.2.6
+==== Excluding stack java-openliberty 0.2.11
+==== Excluding stack quarkus 0.3.3
+==== Excluding stack nodejs 0.3.5
+==== Adding stack nodejs-express 0.4.8
+== fetching https://github.com/kabanero-io/collections/releases/download/0.9.0/kabanero-index.yaml
+== Adding stacks from index https://github.com/kabanero-io/collections/releases/download/0.9.0/kabanero-index.yaml
+==== Excluding stack java-microprofile 0.2.27
+==== Adding stack java-openliberty 0.2.3
+==== Excluding stack java-spring-boot2 0.3.29
+==== Excluding stack nodejs-express 0.4.8
+==== Excluding stack nodejs 0.3.6
  == Running post_build.d scripts
  ==== Running build_nginx.sh
  == Done post_build.d scripts
@@ -194,29 +194,31 @@ Creating consolidated index for default
 
  Open the `default-index.yaml` file to view the consolidated information for each stack in your configuration. For example, the last stack in the list is `nodejs-express`:
 
- ```
- - default-template: simple
-  description: Express web framework for Node.js
-  id: nodejs-express
-  image: docker.io/appsody/nodejs-express:0.4.3
-  language: nodejs
-  license: Apache-2.0
-  maintainers:
-  - email: vieuxtech@gmail.com
-    github-id: sam-github
-    name: Sam Roberts
-  name: Node.js Express
-  requirements:
-    appsody-version: '>= 0.2.7'
-    docker-version: '>= 17.09.0'
-  src: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.3/incubator.nodejs-express.v0.4.3.source.tar.gz
-  templates:
-  - id: simple
-    url: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.3/incubator.nodejs-express.v0.4.3.templates.simple.tar.gz
-  - id: scaffold
-    url: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.3/incubator.nodejs-express.v0.4.3.templates.scaffold.tar.gz
-  version: 0.4.3
   ```
+  - id: nodejs-express
+    name: Node.js Express
+    version: 0.4.8
+    description: Express web framework for Node.js
+    license: Apache-2.0
+    language: nodejs
+    maintainers:
+    - name: Sam Roberts
+      email: vieuxtech@gmail.com
+      github-id: sam-github
+    default-template: simple
+    src: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.8/incubator.nodejs-express.v0.4.8.source.tar.gz
+    templates:
+    - id: kafka
+      url: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.8/incubator.nodejs-express.v0.4.8.templates.kafka.tar.gz
+    - id: simple
+      url: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.8/incubator.nodejs-express.v0.4.8.templates.simple.tar.gz
+    - id: scaffold
+      url: https://github.com/appsody/stacks/releases/download/nodejs-express-v0.4.8/incubator.nodejs-express.v0.4.8.templates.scaffold.tar.gz
+    requirements:
+      docker-version: '>= 17.09.0'
+      appsody-version: '>= 0.2.7'
+    image: docker.io/appsody/nodejs-express:0.4.8
+```
 
 Congratulations! You have built your first stack hub index file that defines a set of filtered application stacks from multiple source repositories.  
 

--- a/publish/stack-java-openliberty/stack-java-openliberty.md
+++ b/publish/stack-java-openliberty/stack-java-openliberty.md
@@ -92,7 +92,7 @@ NAME        URL
 Next, run the following command to add the URL for the public Kabanero stack hub:
 
 ```shell
-appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Check the repositories again by running `appsody repo list` to see that your repository was added. The output is similar to the following example:
@@ -100,7 +100,7 @@ Check the repositories again by running `appsody repo list` to see that your rep
 ```shell
 NAME        URL
 *incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 In this example, the asterisk (\*) shows that `incubator` is the default repository. Run the following command to set `kabanero` as the default repository:
@@ -114,7 +114,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 ```shell
 NAME        URL
 incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 **Recommendation**: To avoid initializing projects that are based on the public application stacks, it's best
@@ -128,7 +128,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 
 ```shell
 NAME        URL
-*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Your development environment is now configured to use the Kabanero application stacks. Next, you need to initialize your project.
@@ -163,7 +163,7 @@ Checking stack requirements...
 Appsody requirements met
 Docker requirements met
 Running appsody init...
-Downloading java-openliberty template project from https://github.com/kabanero-io/collections/releases/download/0.6.4/java-openliberty.v0.2.3.templates.default.tar.gz
+Downloading java-openliberty template project from https://github.com/kabanero-io/collections/releases/download/0.9.0/java-openliberty.v0.2.3.templates.default.tar.gz
 Download complete. Extracting files from /Users/myuser/appsody/java-openliberty/java-openliberty.tar.gz
 Setting up the development environment
 Your Appsody project name has been set to java-openliberty
@@ -187,10 +187,10 @@ Running command: docker pull docker.io/kabanerobeta/java-openliberty:0.2
 [InitScript] [INFO] BUILD SUCCESS
 [InitScript] [INFO] ------------------------------------------------------------------------
 [InitScript] [INFO] Total time:  2.556 s
-[InitScript] [INFO] Finished at: 2020-04-07T13:19:45+01:00
+[InitScript] [INFO] Finished at: 2020-05-15T13:19:45+01:00
 [InitScript] [INFO] ------------------------------------------------------------------------
 Successfully added your project to /Users/myuser/.appsody/project.yaml
-Your Appsody project ID has been set to 20200407131945.49100100
+Your Appsody project ID has been set to 20200515131945.49100100
 Successfully initialized Appsody project with the java-openliberty stack and the default template.
 ```
 

--- a/publish/stack-nodejs-express/stack-nodejs-express.md
+++ b/publish/stack-nodejs-express/stack-nodejs-express.md
@@ -97,7 +97,7 @@ NAME        URL
 Next, run the following command to add the URL for the public Kabanero stack hub:
 
 ```
-appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Check the repositories again by running `appsody repo list` to see that your repository was added. The output is similar to the following example:
@@ -105,7 +105,7 @@ Check the repositories again by running `appsody repo list` to see that your rep
 ```
 NAME        URL
 *incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 In this example, the asterisk (\*) shows that `incubator` is the default repository. Run the following command to set `kabanero` as the default repository:
@@ -119,7 +119,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 ```
 NAME        URL
 incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 **Recommendation**: To avoid initializing projects that are based on the Appsody application stacks, it's best to remove `incubator` from the list. Run the following command to remove the `incubator` repository:
@@ -134,7 +134,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 
 ```
 NAME     	URL
-*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Your development environment is now configured to use the Kabanero application stacks. Next, you need to initialize your project.
@@ -167,20 +167,20 @@ appsody init nodejs-express
 The output from the command is similar to the following example:
 
 ```
-Downloading nodejs-express template project from https://github.com/kabanero-io/collections/releases/download/0.6.4/nodejs-express.v0.2.10.templates.simple.tar.gz
+Downloading nodejs-express template project from https://github.com/kabanero-io/collections/releases/download/0.9.0/nodejs-express.v0.4.8.templates.simple.tar.gz
 Download complete. Extracting files from /Users/myuser/appsody/simple-nodejs-express/nodejs-express.tar.gz
 Setting up the development environment
 Your Appsody project name has been set to simple-nodejs-express
-Pulling docker image docker.io/kabanerobeta/nodejs-express:0.2
-Running command: docker pull docker.io/kabanerobeta/nodejs-express:0.2
-0.2: Pulling from kabanerobeta/nodejs-express
+Pulling docker image docker.io/kabanerobeta/nodejs-express:0.4
+Running command: docker pull docker.io/kabanerobeta/nodejs-express:0.4
+0.4: Pulling from kabanerobeta/nodejs-express
 ..
 ..
-Status: Downloaded newer image for kabanerobeta/nodejs-express:0.2
-docker.io/kabanerobeta/nodejs-express:0.2
-Running command: docker run --rm --entrypoint /bin/bash docker.io/kabanerobeta/nodejs-express:0.2 -c "find /project -type f -name .appsody-init.sh"
+Status: Downloaded newer image for kabanerobeta/nodejs-express:0.4
+docker.io/kabanerobeta/nodejs-express:0.4
+Running command: docker run --rm --entrypoint /bin/bash docker.io/kabanerobeta/nodejs-express:0.4 -c "find /project -type f -name .appsody-init.sh"
 Successfully added your project to /Users/myuser/.appsody/project.yaml
-Your Appsody project ID has been set to 20200407090805.07014400
+Your Appsody project ID has been set to 20200515090805.07014400
 Successfully initialized Appsody project with the nodejs-express stack and the default template.
 ```
 
@@ -221,11 +221,11 @@ After some time, you see a message similar to the following example:
 ```
 [Container] Running command:  npm start
 [Container]
-[Container] > nodejs-express@0.2.10 start /project
+[Container] > nodejs-express@0.4.8 start /project
 [Container] > node server.js
 [Container]
-[Container] [Tue Apr 07 12:58:44 2020] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 5.1.1.202003121616 (Agent Core 4.0.5)
-[Container] [Tue Apr 07 12:58:45 2020] com.ibm.diagnostics.healthcenter.mqtt INFO: Connecting to broker localhost:1883
+[Container] [Tue May  15 12:58:44 2020] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 5.1.1.202003121616 (Agent Core 4.0.5)
+[Container] [Tue May  15 12:58:45 2020] com.ibm.diagnostics.healthcenter.mqtt INFO: Connecting to broker localhost:1883
 [Container] App started on PORT 3000
 ```
 

--- a/publish/stack-nodejs/stack-nodejs.md
+++ b/publish/stack-nodejs/stack-nodejs.md
@@ -90,7 +90,7 @@ NAME        URL
 Next, run the following command to add the URL for the public Kabanero stack hub:
 
 ```shell
-appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Check the repositories again by running `appsody repo list` to see that your repository was added. The output is similar to the following example:
@@ -98,7 +98,7 @@ Check the repositories again by running `appsody repo list` to see that your rep
 ```shell
 NAME        URL
 *incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 In this example, the asterisk (\*) shows that `incubator` is the default repository. Run the following command to set `kabanero` as the default repository:
@@ -112,7 +112,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 ```shell
 NAME        URL
 incubator   https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 **Recommendation**: To avoid initializing projects that are based on the public application stacks, it's best
@@ -126,7 +126,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 
 ```shell
 NAME        URL
-*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Your development environment is now configured to use your customized application stacks. Next, you need to initialize your project.
@@ -161,7 +161,7 @@ Checking stack requirements...
 Docker requirements met
 Appsody requirements met
 Running appsody init...
-Downloading nodejs template project from https://github.com/kabanero-io/collections/releases/download/0.6.4/nodejs.v0.3.3.templates.simple.tar.gz
+Downloading nodejs template project from https://github.com/kabanero-io/collections/releases/download/0.9.0/nodejs.v0.3.6.templates.simple.tar.gz
 Download complete. Extracting files from /Users/myuser/appsody/simple-nodejs/nodejs.tar.gz
 Setting up the development environment
 Your Appsody project name has been set to simple-nodejs
@@ -175,7 +175,7 @@ docker.io/kabanero/nodejs:0.3
 [Warning] The stack image does not contain APPSODY_PROJECT_DIR. Using /project
 Running command: docker run --rm --entrypoint /bin/bash docker.io/kabanero/nodejs:0.3 -c "find /project -type f -name .appsody-init.sh"
 Successfully added your project to /Users/myuser/.appsody/project.yaml
-Your Appsody project ID has been set to 20200402132709.84166800
+Your Appsody project ID has been set to 20200515132709.84166800
 Successfully initialized Appsody project with the nodejs stack and the default template.
 
 ```
@@ -234,10 +234,10 @@ up to date in 0.733s
 ..
 [Container] Running command:  npm start --node-options --require=appmetrics-dash/attach
 [Container]
-[Container] > nodejs-simple@0.1.0 start /project/user-app
+[Container] > nodejs-simple@0.3.6 start /project/user-app
 [Container] > node app.js
 [Container]
-[Container] [Tue Apr  7 08:03:53 2020] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 5.1.1.202003102147 (Agent Core 4.0.5)
+[Container] [Tue May 15 08:03:53 2020] com.ibm.diagnostics.healthcenter.loader INFO: Node Application Metrics 5.1.1.202003102147 (Agent Core 4.0.5)
 [Container] Hello from Node.js 12!
 ```
 

--- a/publish/stack-springboot2/stack-springboot2.md
+++ b/publish/stack-springboot2/stack-springboot2.md
@@ -90,7 +90,7 @@ NAME        URL
 Next, run the following command to add the URL for the public Kabanero stack hub:
 
 ```shell
-appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Check the repositories again by running `appsody repo list` to see that your repository was added. The output is similar to the following example:
@@ -98,7 +98,7 @@ Check the repositories again by running `appsody repo list` to see that your rep
 ```shell
 NAME        URL
 *incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 In this example, the asterisk (\*) shows that `incubator` is the default repository. Run the following command to set `kabanero` as the default repository:
@@ -112,7 +112,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 ```shell
 NAME        URL
 incubator https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
-*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 **Recommendation**: To avoid initializing projects that are based on the public application stacks, it's best
@@ -126,7 +126,7 @@ Check the available repositories again by running `appsody repo list` to see tha
 
 ```shell
 NAME        URL
-*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero   https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 Your development environment is now configured to use the Kabanero application stacks. Next, you need to initialize your project.
@@ -161,7 +161,7 @@ Checking stack requirements...
 Docker requirements met
 Appsody requirements met
 Running appsody init...
-Downloading java-spring-boot2 template project from https://github.com/kabanero-io/collections/releases/download/0.6.4/java-spring-boot2.v0.3.28.templates.default.tar.gz
+Downloading java-spring-boot2 template project from https://github.com/kabanero-io/collections/releases/download/0.9.0/java-spring-boot2.v0.3.29.templates.default.tar.gz
 Download complete. Extracting files from /Users/myuser/appsody/simple-spring-boot2/java-spring-boot2.tar.gz
 Setting up the development environment
 Your Appsody project name has been set to simple-spring-boot2
@@ -178,7 +178,7 @@ Project extracted to /Users/myuser/appsody/simple-spring-boot2/.appsody_init
 Running command: docker rm simple-spring-boot2-extract -f
 Running command: ./.appsody-init.sh
 Successfully added your project to /Users/myuser/.appsody/project.yaml
-Your Appsody project ID has been set to 20200407092833.06544700
+Your Appsody project ID has been set to 20200515092833.06544700
 Successfully initialized Appsody project with the java-spring-boot2 stack and the default template.
 ```
 **Note:** Some lines (..) are removed for clarity.
@@ -223,9 +223,9 @@ appsody run
 The CLI launches a local Docker image that contains an Apache Tomcat server that hosts the microservice. After some time, you see a message similar to the following example:
 
 ```shell
-[Container] 2020-04-07 17:28:44.066  INFO 171 --- [  restartedMain] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 4 endpoint(s) beneath base path '/actuator'
-[Container] 2020-04-07 17:28:44.205  INFO 171 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
-[Container] 2020-04-07 17:28:44.209  INFO 171 --- [  restartedMain] application.Main                         : Started Main in 6.051 seconds (JVM running for 6.923)
+[Container] 2020-05-15 17:28:44.066  INFO 171 --- [  restartedMain] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 4 endpoint(s) beneath base path '/actuator'
+[Container] 2020-05-15 17:28:44.205  INFO 171 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
+[Container] 2020-05-15 17:28:44.209  INFO 171 --- [  restartedMain] application.Main                         : Started Main in 6.051 seconds (JVM running for 6.923)
 ```
 
 This message indicates that the Tomcat server is started. Browse to `http://localhost:8080` and you can see the splash screen.
@@ -290,9 +290,9 @@ After you save, the source compiles and the application updates. You see message
 [Container] [INFO] BUILD SUCCESS
 [Container] [INFO] ------------------------------------------------------------------------
 [Container] [INFO] Total time:  3.585 s
-[Container] [INFO] Finished at: 2020-04-02T17:34:37Z
+[Container] [INFO] Finished at: 2020-05-15T17:34:37Z
 [Container] [INFO] ------------------------------------------------------------------------
-[Container] 2020-04-02 17:34:38.316  INFO 171 --- [      Thread-15] o.s.s.concurrent.ThreadPoolTaskExecutor  : Shutting down ExecutorService 'applicationTaskExecutor'
+[Container] 2020-05-15 17:34:38.316  INFO 171 --- [      Thread-15] o.s.s.concurrent.ThreadPoolTaskExecutor  : Shutting down ExecutorService 'applicationTaskExecutor'
 [Container]
 [Container]   .   ____          _            __ _ _
 [Container]  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
@@ -302,10 +302,10 @@ After you save, the source compiles and the application updates. You see message
 [Container]  =========|_|==============|___/=/_/_/_/
 [Container]  :: Spring Boot ::        (v2.1.6.RELEASE)
 ...
-[Container] 2020-04-02 17:34:39.711  INFO 171 --- [  restartedMain] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 4 endpoint(s) beneath base path '/actuator'
-[Container] 2020-04-02 17:34:39.772  INFO 171 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
-[Container] 2020-04-02 17:34:39.773  INFO 171 --- [  restartedMain] application.Main                         : Started Main in 1.403 seconds (JVM running for 362.487)
-[Container] 2020-04-02 17:34:39.788  INFO 171 --- [  restartedMain] .ConditionEvaluationDeltaLoggingListener : Condition evaluation unchanged
+[Container] 2020-05-15 17:34:39.711  INFO 171 --- [  restartedMain] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 4 endpoint(s) beneath base path '/actuator'
+[Container] 2020-05-15 17:34:39.772  INFO 171 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
+[Container] 2020-05-15 17:34:39.773  INFO 171 --- [  restartedMain] application.Main                         : Started Main in 1.403 seconds (JVM running for 362.487)
+[Container] 2020-05-15 17:34:39.788  INFO 171 --- [  restartedMain] .ConditionEvaluationDeltaLoggingListener : Condition evaluation unchanged
 ```
 
 If you browse to the `http://localhost:8080/example` URL, the endpoint response is displayed, as shown in the following image:

--- a/publish/using-appsody-cli/using-appsody-cli.md
+++ b/publish/using-appsody-cli/using-appsody-cli.md
@@ -64,12 +64,12 @@ As a developer, your enterprise architect might provide you with a URL that poin
 
 To add this configuration information to your local development environment, use the `appsody repo add <repo-name> <URL>` command, supplying a name for the repository and the URL that contains the `index.yaml` file.
 
-In this example, you will add the public Kabanero stack hub, which has the URL `https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml`.
+In this example, you will add the public Kabanero stack hub, which has the URL `https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml`.
 
 - Run the following command:
 
 ```
-appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+appsody repo add kabanero https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 - Check that the repository changes are added successfully by running the `appsody repo list` command
@@ -79,7 +79,7 @@ again. The output should be similar to the following example:
 NAME          URL
 *incubator    https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 experimental  https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
-kabanero      https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+kabanero      https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 ```
 
 ### Setting your default repository
@@ -98,7 +98,7 @@ appsody repo set-default kabanero
 
 ```
 NAME            URL
-*kabanero       https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.8.0/kabanero-stack-hub-index.yaml
+*kabanero       https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.9.0/kabanero-stack-hub-index.yaml
 incubator       https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml
 experimental    https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml
 ```
@@ -120,12 +120,13 @@ appsody list kabanero
 The output is similar to the following example, which provides detailed information for each stack:
 
 ```
-REPO          	ID               	VERSION  	TEMPLATES        	DESCRIPTION                                              
-kabanero      	java-microprofile	0.2.26   	*default         	Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
-kabanero      	java-openliberty 	0.2.3    	*default         	Open Liberty & OpenJ9 using Maven                        
-kabanero      	java-spring-boot2	0.3.28   	*default, kotlin 	Spring Boot using OpenJ9 and Maven                       
-kabanero      	nodejs           	0.3.3    	*simple          	Runtime for Node.js applications                         
-kabanero      	nodejs-express   	0.2.10   	scaffold, *simple	Express web framework for Node.js
+REPO               ID               	VERSION  	TEMPLATES               	DESCRIPTION                                              
+kabanero	   java-openliberty 	0.2.11   	*default, kafka         	Eclipse MicroProfile & Jakarta EE on Open Liberty & OpenJ9
+           	                 	         	                                using Maven                                                 
+kabanero	   java-spring-boot2	0.3.29   	*default, kafka, kotlin 	Spring Boot using OpenJ9 and Maven                          
+kabanero	   nodejs           	0.3.6    	*simple                 	Runtime for Node.js applications                            
+kabanero	   nodejs-express   	0.4.8    	kafka, scaffold, *simple	Express web framework for Node.js                           
+kabanero           quarkus          	0.3.3    	*default, kafka         	Quarkus runtime for running Java applications
 ```
 
 In the output you can see multiple application stacks (IDs) in the `kabanero` repository. Each stack includes a version number, one or more templates (an asterisk (\*) indicates the default template), and a description.
@@ -181,7 +182,7 @@ To list all the stack-based containers that are running in your local environmen
 
 ```
 CONTAINER ID	NAME            IMAGE                       	STATUS
-f20ec098a612	my-project-dev	kabanero/nodejs-express:0.2	  Up 8 minutes
+f20ec098a612	my-project-dev	kabanero/nodejs-express:0.4	Up 8 minutes
 ```
 
 ### Stopping your Appsody container


### PR DESCRIPTION
All the stack guides are updated to reflect Kabanero v0.9.0: https://github.com/kabanero-io/docs/issues/388.

In addition, MicroProfile reference in using-appsodi-cli.md is removed: https://github.com/kabanero-io/docs/issues/389

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>